### PR TITLE
Fix README and nic type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Requirements
 
 - A Linux system
-- Libvirt and virt-install.
+- Libvirt, virt-install and virt-viewer (and qemu/firewalld depending on your system)
+- CDRtools (genisoimage)
 - ESXi ISO image
 
 # Build your image
@@ -10,6 +11,7 @@
 ./build.sh isos/VMware-VMvisor-Installer-6.5.0.update01-5969303.x86_64.iso
 ./build.sh isos/VMware-VMvisor-Installer-6.7.0-8169922.x86_64.iso
 ./build.sh isos/VMware-VMvisor-Installer-6.7.0.update03-14320388.x86_64.iso
+./build.sh isos/VMware-VMvisor-Installer-7.0U3-18644231.x86_64.iso
 ```
 
 # KVM configuration

--- a/build.sh
+++ b/build.sh
@@ -100,11 +100,12 @@ virt-install --connect qemu:///system \
 sleep 10
 sudo qemu-img convert -f qcow2 -O qcow2 -c /var/lib/libvirt/images/esxi-${VERSION}_tmp.qcow2 esxi-${VERSION}.qcow2
 cp default_config.yaml esxi-${VERSION}.yaml
+
+nic_model='e1000e'
 if echo $VERSION|egrep '^7'; then
-    echo "default_nic_model: e1000e" >> esxi-${VERSION}.yaml
-else
-    echo "default_nic_model: e1000" >> esxi-${VERSION}.yaml
+    nic_model='e1000e'
 fi
+echo "default_nic_model: $nic_model" >> esxi-${VERSION}.yaml
 
 sudo virsh undefine --remove-all-storage esxi-${VERSION}_tmp
 sudo rm /var/lib/libvirt/images/new.iso
@@ -115,4 +116,4 @@ echo "You image is ready! Do use it:
 
     OpenStack:
         source ~/openrc.sh
-        openstack image create --disk-format qcow2 --container-format bare --file esxi-${VERSION}.qcow2 --property hw_disk_bus=sata --property hw_cpu_policy=dedicated --property hw_cdrom_bus=ide --property hw_vif_model=e1000 --property hw_boot_menu=true --property hw_qemu_guest_agent=no --min-disk 1 --min-ram 4096 esxi-${VERSION}"
+        openstack image create --disk-format qcow2 --container-format bare --file esxi-${VERSION}.qcow2 --property hw_disk_bus=sata --property hw_cpu_policy=dedicated --property hw_cdrom_bus=ide --property hw_vif_model=$nic_model --property hw_boot_menu=true --property hw_qemu_guest_agent=no --min-disk 1 --min-ram 4096 esxi-${VERSION}"

--- a/build.sh
+++ b/build.sh
@@ -82,7 +82,7 @@ sudo sed -i s,timeout=5,timeout=1, ${TARGET_ISO}/boot.cfg
 sudo sed -i 's,\(kernelopt=.*\),\1 ks=cdrom:/KS_CUST.CFG,' ${TARGET_ISO}/boot.cfg
 sudo sed -i 's,TIMEOUT 80,TIMEOUT 1,' ${TARGET_ISO}/isolinux.cfg
 
-sudo genisoimage -relaxed-filenames -J -R -o ${TMPDIR}/new.iso -b isolinux.bin -c boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -eltorito-alt-boot -e efiboot.img -no-emul-boot ${TARGET_ISO}
+sudo genisoimage -relaxed-filenames -J -R -o ${TMPDIR}/new.iso -b isolinux.bin -c boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -eltorito-alt-boot -eltorito-boot efiboot.img -no-emul-boot ${TARGET_ISO}
 
 sudo mv ${TARGET_ISO}.iso /var/lib/libvirt/images/
 sudo chmod 644 /var/lib/libvirt/images/new.iso


### PR DESCRIPTION
- Fix requirements in the readme 
- Added example on how to import 7.x
- Fix import statement for OpenStack when ESXI 7.x is used. While `e1000e` is used during the installer, the `openstack` import statement used `e1000` - aligned this in both cases now